### PR TITLE
ft(nerdtree): automatically launch nerdtree

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -305,3 +305,6 @@ try
 catch
     " No such file? No problem, just ignore it...
 endtry
+
+" Start NERDTree and put the cursor back in the other window.
+autocmd VimEnter * NERDTree | wincmd p


### PR DESCRIPTION
Upon startup of vim, automatically start nerdtree and put the cursor
back into the editing window. This should encourage users to use
nerdtree more often.