### PR TITLE
fx: Configure tabs for shellscripts

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -218,6 +218,7 @@ au BufNewFile,BufRead *.sh,*.bash setlocal expandtab ts=2 sw=2
 au BufNewFile,BufRead *.go setlocal noet ts=4 sw=4 sts=4
 au BufNewFile,BufRead *.pp setlocal expandtab ts=2 sw=2
 au BufNewFile,BufRead *rc set expandtab ts=2 sw=2 sts=2
+autocmd FileType sh set expandtab ts=2 sw=2
 autocmd FileType dockerfile set noexpandtab
 autocmd FileType fstab,systemd set noexpandtab
 autocmd FileType gitconfig,sh,toml set noexpandtab


### PR DESCRIPTION
Instead of using tabs, use spaces

Signed-off-by: Jeffrey Bouter <jb@warpnet.nl>