### PR TITLE
Stop automatically opening NERDTree

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -307,5 +307,3 @@ catch
     " No such file? No problem, just ignore it...
 endtry
 
-" Start NERDTree and put the cursor back in the other window.
-autocmd VimEnter * NERDTree | wincmd p


### PR DESCRIPTION
Stop automatically opening NERDTree as it causes a large delay on macOS when opening Vim.

The removed lines can be added to the `~/.vimrc_personal` file to keep the previous behaviour:

```vim
" Start NERDTree and put the cursor back in the other window.
autocmd VimEnter * NERDTree | wincmd p
```